### PR TITLE
feat: VS Code/Cursor を対話式で選択可能に

### DIFF
--- a/vscode-dotfiles/vscode_install.sh
+++ b/vscode-dotfiles/vscode_install.sh
@@ -1,28 +1,58 @@
 #!/bin/sh
 
 SCRIPT_DIR=$(cd $(dirname $0) && pwd)
-VSCODE_SETTING_DIR=~/Library/Application\ Support/Code/User
 
-rm "$VSCODE_SETTING_DIR/settings.json"
-ln -s "$SCRIPT_DIR/settings.json" "${VSCODE_SETTING_DIR}/settings.json"
+# エディタ選択
+echo "セットアップするエディタを選択してください:"
+echo "  1) VS Code"
+echo "  2) Cursor"
+printf "選択 [1/2]: "
+read choice
 
-rm "$VSCODE_SETTING_DIR/keybindings.json"
-ln -s "$SCRIPT_DIR/keybindings.json" "${VSCODE_SETTING_DIR}/keybindings.json"
+case "$choice" in
+  1)
+    EDITOR_NAME="VS Code"
+    SETTING_DIR=~/Library/Application\ Support/Code/User
+    EDITOR_CMD="code"
+    ;;
+  2)
+    EDITOR_NAME="Cursor"
+    SETTING_DIR=~/Library/Application\ Support/Cursor/User
+    EDITOR_CMD="cursor"
+    ;;
+  *)
+    echo "Error: 無効な選択です。1 または 2 を入力してください。"
+    exit 1
+    ;;
+esac
 
-# install extention
-# code コマンドが見つからない場合は、インストール方法を案内して終了
-if ! command -v code &> /dev/null; then
-  echo "Error: 'code' command not found."
+echo "${EDITOR_NAME} のセットアップを開始します..."
+
+# シンボリックリンクを作成
+rm "$SETTING_DIR/settings.json" 2>/dev/null
+ln -s "$SCRIPT_DIR/settings.json" "${SETTING_DIR}/settings.json"
+echo "  settings.json をリンクしました"
+
+rm "$SETTING_DIR/keybindings.json" 2>/dev/null
+ln -s "$SCRIPT_DIR/keybindings.json" "${SETTING_DIR}/keybindings.json"
+echo "  keybindings.json をリンクしました"
+
+# install extension
+# CLI コマンドが見つからない場合は、インストール方法を案内して終了
+if ! command -v "$EDITOR_CMD" &> /dev/null; then
+  echo "Error: '${EDITOR_CMD}' command not found."
   echo "Please install it by:"
-  echo "  1. Open VS Code"
+  echo "  1. Open ${EDITOR_NAME}"
   echo "  2. Press Cmd+Shift+P"
-  echo "  3. Run 'Shell Command: Install 'code' command in PATH'"
+  echo "  3. Run 'Shell Command: Install '${EDITOR_CMD}' command in PATH'"
   exit 1
 fi
 
 cat "$SCRIPT_DIR/extensions" | while read line
 do
-  code --install-extension $line
+  "$EDITOR_CMD" --install-extension $line
 done
 
-code --list-extensions > "$SCRIPT_DIR/extensions"
+"$EDITOR_CMD" --list-extensions > "$SCRIPT_DIR/extensions"
+
+echo "${EDITOR_NAME} のセットアップが完了しました！"


### PR DESCRIPTION
## Summary
- `vscode_install.sh` で VS Code と Cursor のどちらかを対話式で選択できるように変更
- 選択に応じて設定ファイルのパスと CLI コマンドを切り替え

## Test plan
- [ ] スクリプトを実行して「1」を選択 → VS Code の設定が更新されることを確認
- [ ] スクリプトを実行して「2」を選択 → Cursor の設定が更新されることを確認
- [ ] 無効な入力（例: 3）でエラーメッセージが表示されることを確認

Closes #26

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables interactive selection of editor and applies settings/extensions accordingly.
> 
> - Prompts user in `vscode_install.sh` to choose `VS Code` or `Cursor`, setting `SETTING_DIR` and `EDITOR_CMD` based on choice
> - Links `settings.json` and `keybindings.json` to the chosen editor's `User` directory and prints status
> - Uses the selected CLI (`code` or `cursor`) to install extensions from `extensions` and to refresh the list
> - Adds CLI existence check with tailored install instructions; exits on invalid choice
> - Removes hardcoded VS Code paths/commands in favor of generalized variables
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fd662b26871795db13d8eacdb3e45de939e9d035. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->